### PR TITLE
[BUGFIX] Handle NULL pi_flexform

### DIFF
--- a/Classes/DataProcessing/DefaultProcessor.php
+++ b/Classes/DataProcessing/DefaultProcessor.php
@@ -43,6 +43,11 @@ class DefaultProcessor implements DataProcessorInterface
     protected function getOptionsFromFlexFormData(array $row)
     {
         $options = [];
+
+        if (is_null($row['pi_flexform'])) {
+            return $options;
+        }
+
         $flexFormAsArray = GeneralUtility::xml2array($row['pi_flexform']);
         if (isset($flexFormAsArray['data']) && is_array($flexFormAsArray['data'])) {
             foreach ($flexFormAsArray['data'] as $base) {

--- a/Classes/EventListener/NewContentElementPreviewRenderer.php
+++ b/Classes/EventListener/NewContentElementPreviewRenderer.php
@@ -25,7 +25,7 @@ final class NewContentElementPreviewRenderer
             $row = $row->getRawRecord()?->toArray() ?? [];
         }
        
-        if ($row['CType'] === 'nstimeline') {
+        if ($row['CType'] === 'nstimeline' && !is_null($row['pi_flexform'])) {
 
             $drawItem = false;
             $headerContent = '';

--- a/Resources/Private/Templates/NsTimeline.html
+++ b/Resources/Private/Templates/NsTimeline.html
@@ -7,8 +7,9 @@
     <f:render section="content" arguments="{content: content}" />
 
     <f:section name="content">
-        <f:render partial="Standard/{f:format.case(mode: 'capital', value: '{content.normalVariation}')}.html" arguments="{_all}"/>
-            
+        <f:if condition="{content.normalVariation}">
+            <f:render partial="Standard/{f:format.case(mode: 'capital', value: '{content.normalVariation}')}.html" arguments="{_all}"/>
+        </f:if>
     </f:section>
 </div>    
 


### PR DESCRIPTION
# Issue

The default value of the `pi_flexform` column in the database is `NULL`.

It is possible for editors to reach that state e.g. by changing the CType of an existing ContentElement, but `GeneralUtility::xml2array` expects a string, causing PHP exceptions in the frontend and backend.

## How to reproduce

1. Create a new ContentElement of type Text or Header
2. Change the `CType` field to Timeline
3. When the `Refresh required` popup appears, select `Save and refresh`
4. Close the editing of the contentElement

Opening the page view in backend , or the page in the frontend will return PHP exceptions:

```
TYPO3\CMS\Core\Utility\GeneralUtility::xml2array(): Argument #1 ($string) must be of type string, null given, called in /app/vendor/nitsan/ns-timeline/Classes/EventListener/NewContentElementPreviewRenderer.php on line 39
```

```
TYPO3\CMS\Core\Utility\GeneralUtility::xml2array(): Argument #1 ($string) must be of type string, null given, called in /app/vendor/nitsan/ns-timeline/Classes/DataProcessing/DefaultProcessor.php on line 46
```

# Changes

When `pi_flexform` is null, then the processing of the FlexForm is skipped. The content will be rendered as empty in both the backend and the frontend:

<img width="453" height="90" alt="image" src="https://github.com/user-attachments/assets/d431743b-7824-4819-a40b-a11ed035d25c" />
